### PR TITLE
Fix search button hover expand behaviour

### DIFF
--- a/theme/scss/site/search.scss
+++ b/theme/scss/site/search.scss
@@ -2,7 +2,11 @@
 	.wp-block-search__inside-wrapper {
 		@extend .input-group;
 		.wp-block-search__button {
-			margin-left: 0px;
+			position: relative;
+			z-index: 2;
+			&:focus {
+				z-index: 5;
+			}
 		}
 	}
 }


### PR DESCRIPTION
When hovering the search button, its margin seems to change back to the default -1px making it appear larger. This fixes that behaviour by correctly applying `.input-group .btn` to `.wp-block-search__button`. 