### PR TITLE
Fix navigation submenu

### DIFF
--- a/theme/scss/site/nav.scss
+++ b/theme/scss/site/nav.scss
@@ -2,9 +2,15 @@
 	@extend .rounded;
 	.wp-block-navigation-item {
 		color: black !important;
-	}
-	.wp-block-navigation-item:hover {
-		background-color: $grey-5;
+		&:first-child {
+			@extend .rounded-top;
+		}
+		&:last-child {
+			@extend .rounded-bottom;
+		}
+		&:hover {
+			background-color: $grey-5;
+		}
 	}
 }
 


### PR DESCRIPTION
When hovering submenu items, the background extends out of the submenu in the corners. This fixes that by rounding the top corners of the 1st submenu item and the bottom corners of the last submenu item.