### PR TITLE
Improve font loading

### DIFF
--- a/functions/enqueues.php
+++ b/functions/enqueues.php
@@ -1,27 +1,31 @@
 <?php
 /**
- * Enqueue scripts and styles.
+ * Bootscout Theme Enqueues
+ *
+ * Handle registration and enqueueing of theme stylesheets and scripts
+ * for both frontend and editor contexts. Fonts are loaded via theme.json.
+ *
+ * @package Bootscout
+ * @subpackage Functions
+ * @since 2.2.3
  */
-function bootscout_theme_preconnect() {
-	echo '<link rel="preconnect" href="https://fonts.googleapis.com">' . PHP_EOL;
-	echo '<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>' . PHP_EOL;
-}
 
+/**
+ * Register and enqueue frontend styles and scripts.
+ *
+ * Enqueues the main theme stylesheet and jQuery library.
+ * Also loads the theme's custom JavaScript file in the footer.
+ * Font files are loaded via theme.json variable font definitions.
+ *
+ * @since 2.2.3
+ * @return void
+ */
 function bootscout_theme_scripts() {
-	// Styles
-	wp_register_style(
-		'Nunito+Sans',
-		'https://fonts.googleapis.com/css2?family=Nunito+Sans:ital,wght@0,400;0,600;0,700;0,900;1,400;1,600;1,700;1,900&display=swap',
-		false,
-		null,
-		null
-	);
-	wp_enqueue_style('Nunito+Sans');
-
+	// Styles - fonts are loaded via theme.json
 	wp_register_style(
 		'theme',
 		get_template_directory_uri() . '/theme/css/site.css',
-		['Nunito+Sans'],
+		[],
 		wp_get_theme()->get('Version')
 	);
 	wp_enqueue_style('theme');
@@ -30,21 +34,31 @@ function bootscout_theme_scripts() {
 	wp_enqueue_script("jquery");  // use WordPress built in jQuery
 
 	wp_enqueue_script('theme-script', get_template_directory_uri() . '/theme/js/site.js', false, null, true);
-
 }
 
+/**
+ * Register and enqueue editor-specific scripts.
+ *
+ * Loads the theme's JavaScript file for the block editor context.
+ * Allows theme JavaScript to enhance the editor experience.
+ *
+ * @since 2.2.3
+ * @return void
+ */
 function bootscout_theme_editor_scripts() {
-	// Styles
 	wp_enqueue_script('theme-editor-script', get_template_directory_uri() . '/theme/js/site.js', false, null, true);
 }
 
 if ( ! function_exists( 'bootscout_theme_pattern_categories' ) ) :
 	/**
-	 * Register pattern categories
+	 * Register custom block pattern categories.
 	 *
+	 * Registers two pattern categories for organizing block patterns:
+	 * - bootscout: General block patterns for scout websites
+	 * - page_layouts: Full page layout patterns
+	 *
+	 * @since 2.2.3
 	 * @return void
-	 * @since Bootscout-theme 2.2.3
-	 *
 	 */
 	function bootscout_theme_pattern_categories() {
 
@@ -68,14 +82,25 @@ endif;
 
 add_filter( 'wpsl_templates', 'custom_templates' , 10, 2);
 
+/**
+ * Register custom WP Store Locator template.
+ *
+ * Adds a custom Bootscout template to the WP Store Locator plugin's
+ * template dropdown on the settings page. The template file allows
+ * customization of the store locator map display.
+ *
+ * @since 2.2.3
+ * @param array $templates Array of available templates for the plugin.
+ * @return array Modified array of templates with Bootscout template added.
+ */
 function custom_templates( $templates ) {
 
 	/**
-	* The 'id' is for internal use and must be unique ( since 2.0 ).
-	* The 'name' is used in the template dropdown on the settings page.
-	* The 'path' points to the location of the custom template,
-	* in this case the folder of your active theme.
-	*/
+	 * The 'id' is for internal use and must be unique ( since 2.0 ).
+	 * The 'name' is used in the template dropdown on the settings page.
+	 * The 'path' points to the location of the custom template,
+	 * in this case the folder of your active theme.
+	 */
 	$templates[] = array (
 		'id'   => 'bootscout',
 		'name' => 'Bootscout',
@@ -85,7 +110,11 @@ function custom_templates( $templates ) {
 	return $templates;
 }
 
-add_action( 'wp_head', 'bootscout_theme_preconnect', 2 );
+/**
+ * Register hooks and actions.
+ *
+ * @since 2.2.3
+ */
 add_action( 'enqueue_block_assets', 'bootscout_theme_scripts', 20 );
 add_action( 'enqueue_block_editor_assets', 'bootscout_theme_editor_scripts');
 add_action( 'init', 'bootscout_theme_pattern_categories' );

--- a/theme.json
+++ b/theme.json
@@ -211,11 +211,7 @@
 		},
 		"custom": {
 			"fontWeight": {
-				"thin": 100,
-				"extra-light": 200,
-				"light": 300,
 				"regular": 400,
-				"medium": 500,
 				"semi-bold": 600,
 				"bold": 700,
 				"extra-bold": 800,
@@ -262,130 +258,16 @@
 					"name": "Nunito Sans",
 					"fontFace": [
 						{
-							"fontFamily": "Open Sans",
-							"fontWeight": "200",
+							"fontFamily": "Nunito Sans",
+							"fontWeight": "400 600 700 800 900",
 							"fontStyle": "normal",
-							"fontStretch": "normal",
 							"src": [ "file:./theme/fonts/NunitoSans.woff2" ]
 						},
 						{
-							"fontFamily": "Open Sans",
-							"fontWeight": "300",
-							"fontStyle": "normal",
-							"fontStretch": "normal",
-							"src": [ "file:./theme/fonts/NunitoSans.woff2" ]
-						},
-						{
-							"fontFamily": "Open Sans",
-							"fontWeight": "400",
-							"fontStyle": "normal",
-							"fontStretch": "normal",
-							"src": [ "file:./theme/fonts/NunitoSans.woff2" ]
-						},
-						{
-							"fontFamily": "Open Sans",
-							"fontWeight": "500",
-							"fontStyle": "normal",
-							"fontStretch": "normal",
-							"src": [ "file:./theme/fonts/NunitoSans.woff2" ]
-						},
-						{
-							"fontFamily": "Open Sans",
-							"fontWeight": "600",
-							"fontStyle": "normal",
-							"fontStretch": "normal",
-							"src": [ "file:./theme/fonts/NunitoSans.woff2" ]
-						},
-						{
-							"fontFamily": "Open Sans",
-							"fontWeight": "700",
-							"fontStyle": "normal",
-							"fontStretch": "normal",
-							"src": [ "file:./theme/fonts/NunitoSans.woff2" ]
-						},
-						{
-							"fontFamily": "Open Sans",
-							"fontWeight": "800",
-							"fontStyle": "normal",
-							"fontStretch": "normal",
-							"src": [ "file:./theme/fonts/NunitoSans.woff2" ]
-						},
-						{
-							"fontFamily": "Open Sans",
-							"fontWeight": "900",
-							"fontStyle": "normal",
-							"fontStretch": "normal",
-							"src": [ "file:./theme/fonts/NunitoSans.woff2" ]
-						},
-						{
-							"fontFamily": "Open Sans",
-							"fontWeight": "1000",
-							"fontStyle": "normal",
-							"fontStretch": "normal",
-							"src": [ "file:./theme/fonts/NunitoSans.woff2" ]
-						},
-						{
-							"fontFamily": "Open Sans",
-							"fontWeight": "200",
+							"fontFamily": "Nunito Sans",
+							"fontWeight": "400 600 700 800 900",
 							"fontStyle": "italic",
-							"fontStretch": "normal",
-							"src": [ "file:./theme/fonts/NunitoSans-italic.woff2" ]
-						},
-						{
-							"fontFamily": "Open Sans",
-							"fontWeight": "300",
-							"fontStyle": "italic",
-							"fontStretch": "normal",
-							"src": [ "file:./theme/fonts/NunitoSans-italic.woff2" ]
-						},
-						{
-							"fontFamily": "Open Sans",
-							"fontWeight": "400",
-							"fontStyle": "italic",
-							"fontStretch": "normal",
-							"src": [ "file:./theme/fonts/NunitoSans-italic.woff2" ]
-						},
-						{
-							"fontFamily": "Open Sans",
-							"fontWeight": "500",
-							"fontStyle": "italic",
-							"fontStretch": "normal",
-							"src": [ "file:./theme/fonts/NunitoSans-italic.woff2" ]
-						},
-						{
-							"fontFamily": "Open Sans",
-							"fontWeight": "600",
-							"fontStyle": "italic",
-							"fontStretch": "normal",
-							"src": [ "file:./theme/fonts/NunitoSans-italic.woff2" ]
-						},
-						{
-							"fontFamily": "Open Sans",
-							"fontWeight": "700",
-							"fontStyle": "italic",
-							"fontStretch": "normal",
-							"src": [ "file:./theme/fonts/NunitoSans-italic.woff2" ]
-						},
-						{
-							"fontFamily": "Open Sans",
-							"fontWeight": "800",
-							"fontStyle": "italic",
-							"fontStretch": "normal",
-							"src": [ "file:./theme/fonts/NunitoSans-italic.woff2" ]
-						},
-						{
-							"fontFamily": "Open Sans",
-							"fontWeight": "900",
-							"fontStyle": "italic",
-							"fontStretch": "normal",
-							"src": [ "file:./theme/fonts/NunitoSans-italic.woff2" ]
-						},
-						{
-							"fontFamily": "Open Sans",
-							"fontWeight": "1000",
-							"fontStyle": "italic",
-							"fontStretch": "normal",
-							"src": [ "file:./theme/fonts/NunitoSans-italic.woff2" ]
+							"src": [ "file:./theme/fonts/NunitoSans-Italic.woff2" ]
 						}
 					]
 				},

--- a/theme.json
+++ b/theme.json
@@ -212,9 +212,7 @@
 		"custom": {
 			"fontWeight": {
 				"regular": 400,
-				"semi-bold": 600,
 				"bold": 700,
-				"extra-bold": 800,
 				"black": 900
 			},
 			"--table-border-width": "2px",
@@ -259,13 +257,13 @@
 					"fontFace": [
 						{
 							"fontFamily": "Nunito Sans",
-							"fontWeight": "400 600 700 800 900",
+							"fontWeight": "400 700 900",
 							"fontStyle": "normal",
 							"src": [ "file:./theme/fonts/NunitoSans.woff2" ]
 						},
 						{
 							"fontFamily": "Nunito Sans",
-							"fontWeight": "400 600 700 800 900",
+							"fontWeight": "400 700 900",
 							"fontStyle": "italic",
 							"src": [ "file:./theme/fonts/NunitoSans-Italic.woff2" ]
 						}


### PR DESCRIPTION
Hi @JackFurby 

I've made some changes to font definitions and loading.

- There was a double load - from local and remote - so I've removed the remote load.
- The font definition in `theme.json` referenced Open Sans instead of Nunito.
- Nunito Sans and the italic variant are variable fonts, so we can take advantage of a variable font definition for the weights.
- scouts.org.uk only uses 3 weights: 400, 900 for headings and 700 for buttons.
- Added some PHP doc in enqueues.php.

I hope you'll find this useful, and either accept the PR or take from it what may be useful.

Thanks
Matt
